### PR TITLE
テスト失敗時のスクリーンショットの取り方を調整

### DIFF
--- a/specs/share/steps/global/custom-screenshot.ts
+++ b/specs/share/steps/global/custom-screenshot.ts
@@ -1,0 +1,24 @@
+import { getPage } from "@/share/lib/browser-control";
+import { CustomScreenshotWriter } from "gauge-ts";
+import * as path from "path";
+
+export default class CustomScreenshot {
+    /**
+     * Gaugeはデフォルトで画面全体のスクリーンショットを撮ってしまうため、
+     * CustomScreenshotWriterで修飾してスクリーンショットにこの関数を使うようにしています。
+     * Playwrightのスクリーンショットを撮る方法を使うことで、
+     * Playwrightで開いている画面だけのスクリーンショットを撮ることができます。
+     * 環境変数のgauge_screenshots_dirで指定されているディレクトリにスクリーンショットを保存します。
+     * @returns スクリーンショットのファイル名
+     */
+    @CustomScreenshotWriter()
+    public static async takeCustomScreenshot(): Promise<string> {
+        const dir = process.env.gauge_screenshots_dir ?? "";
+        const filePath = path.join(dir, `screenshot-${Date.now()}.png`);
+
+        const page = await getPage();
+        await page.screenshot({ path: filePath, fullPage: true });
+
+        return path.basename(filePath);
+    }
+}


### PR DESCRIPTION
## やったこと

- テスト失敗時のスクリーンショットが、画面全体になっていたので、ブラウザのものだけになるように調整