### PR TITLE
昨今話題のnpm汚染対策を入れた

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,23 @@ jobs:
       - name: Compile
         run: pnpm compile
 
+  audit:
+    name: Audit dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup Node.js environment
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+        with:
+          install_args: "node"
+      - name: Enable pnpm via Corepack
+        run: corepack enable pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Audit dependencies
+        run: pnpm audit
+
   e2e-health-check:
     name: E2E Health Check (use Gauge & Playwright)
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GaugeとPlaywrightを組み合わせて作ったE2Eテストの実行環境で�
 クローンしたらすぐに使用・拡張していけるような完成度を目指しています。  
 あわせて、自身の運用の練習用としても活用していく想定です。
 
-## 使用技術スタック
+## 🚀 使用技術スタック
 
 本リポジトリは以下の技術スタックを採用しています。
 
@@ -23,7 +23,7 @@ GaugeとPlaywrightを組み合わせて作ったE2Eテストの実行環境で�
 - ライブラリアップデート: Renovate
 - CI: GitHub Actions
 
-## 環境構築 for Mac
+## 🛠️ 環境構築 for Mac
 
 ### 前提条件
 
@@ -82,7 +82,7 @@ node -v
 pnpm -v
 ```
 
-## 使用方法
+## 📖 使用方法
 
 ### テスト実行
 
@@ -139,7 +139,7 @@ pnpm show-trace "<トレースファイルのパス>"
 pnpm open-report
 ```
 
-## プロジェクト構成
+## 📁 プロジェクト構成
 
 ```
 gauge-playwright-boilerplate/
@@ -163,14 +163,14 @@ gauge-playwright-boilerplate/
 └── mise.toml                  # ランタイムバージョン設定
 ```
 
-## トラブルシューティング
+## 🔧 トラブルシューティング
 
 ### テスト実行時にエラーが発生する
 
 - `pnpm clean:install` を実行して、依存関係を再インストールします
 - それでもうまくいかなければ、エラーログを読み適切な対処をしましょう
 
-## 謝辞
+## 🙏 謝辞
 
 - サンプル実装として用意したテストは、[HOTEL PLANISPHERE \- テスト自動化練習サイト](https://hotel-example-site.takeyaqa.dev/ja/index.html)さんを対象にさせていただいております。ありがとうございます。
 - このリポジトリで実装しているアイディアは、[Scalebase株式会社](https://scalebase.co.jp/)で培った知見をベースにしています。ありがとうございます。

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 onlyBuiltDependencies:
   - '@getgauge/cli'
   - protobufjs
-  - taiko
+# See: https://pnpm.io/settings#minimumreleaseage
+minimumReleaseAge: 1440 # 1 day

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "labels": ["renovatebot"],
   "timezone": "Asia/Tokyo",
   "rangeStrategy": "pin",
+  "minimumReleaseAge": "7 days",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "packageRules": [
     {


### PR DESCRIPTION
## やったこと

- renovateのアップデート対象がすぐに出てこないようにする（7日）
- pnpm上でもアップデート対象が出てくるまでに少し時間をもたせる（1日）
- GitHub Actionsでも `pnpm audit` を動かすようにしてみる

## 参考文献

https://zenn.dev/azu/articles/ad168118524135